### PR TITLE
Change geo field from TEXT to MEDIUMTEXT

### DIFF
--- a/NeatlineFeaturesPlugin.php
+++ b/NeatlineFeaturesPlugin.php
@@ -93,7 +93,7 @@ class NeatlineFeaturesPlugin extends Omeka_Plugin_AbstractPlugin
                 item_id         INT(10)        UNSIGNED NOT NULL,
                 element_text_id INT(10)        UNSIGNED NOT NULL,
                 is_map          TINYINT(1)     NOT NULL DEFAULT 0,
-                geo             TEXT           ,
+                geo             MEDIUMTEXT           ,
                 zoom            SMALLINT(2)    NOT NULL DEFAULT 3,
                 center_lon      DECIMAL(20, 7) NOT NULL DEFAULT 0.0,
                 center_lat      DECIMAL(20, 7) NOT NULL DEFAULT 0.0,


### PR DESCRIPTION
Geo data such as borders can easily exceed TEXT's 16Kb limit. This also matches the size of the `omeka_element_text.text` column.
